### PR TITLE
Fix automatic detection of commit tag names: only report exact matches

### DIFF
--- a/docker/util.py
+++ b/docker/util.py
@@ -41,7 +41,7 @@ def get_commit_subject(ref: str) -> Optional[str]:
 
 
 def get_commit_tags(ref: str) -> List[str]:
-    exit_code, output = subprocess.getstatusoutput(f"git describe --tags {ref}")
+    exit_code, output = subprocess.getstatusoutput(f"git describe --tags --exact-match {ref}")
     return output.splitlines() if exit_code == 0 else []
 
 


### PR DESCRIPTION
... was initially quite shocked to see that I'm deploying on `dev` something, that is allegedly already `live`, but in fact was just committed...