### PR TITLE
Automatically set production flag for live environment

### DIFF
--- a/docker/ghd.py
+++ b/docker/ghd.py
@@ -10,6 +10,7 @@ from output import print_info
 from util import DependentOptionDefault, bool_to_str, get_commit_subject, get_commit_tags, get_head_rev, \
     get_repo_fallback, handle_errors, parse_require_context
 
+PRODUCTION_ENVIRONMENTS = ("live",)
 ORDERED_ENVIRONMENTS = ("dev", "test", "live")
 
 
@@ -85,9 +86,11 @@ async def cmd_list(repo: str, verbose: bool, limit: int, environment: Optional[s
               default=False,
               help="Mark as transient environment")
 @click.option("-p", "--production/--no-production",
+              cls=DependentOptionDefault,
+              depends_on="environment",
               required=False,
               prompt=True,
-              default=False,
+              default=lambda environment: environment in PRODUCTION_ENVIRONMENTS,
               help="Mark as production environment")
 @click.option("-d", "--description",
               cls=DependentOptionDefault,

--- a/docker/github.py
+++ b/docker/github.py
@@ -2,7 +2,7 @@ import enum
 import json
 import os
 import sys
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence
 from urllib.parse import urlencode
 
 import aiohttp
@@ -112,7 +112,7 @@ class GitHub:
             return []
 
     async def verify_ref_is_deployed_in_previous_environment(self, ref: str, environment: str,
-                                                             ordered_environments: Tuple[str]):
+                                                             ordered_environments: Sequence[str]):
         index = ordered_environments.index(environment)
         previous_environment = ordered_environments[index - 1] if index != 0 else None
 


### PR DESCRIPTION
I this that it's pretty easy to forget production flag and click can be elegantly hacked to set the right default automatically, so why not?