### PR TITLE
fix(gui): ensure ui is flushed to console when using watch mode

### DIFF
--- a/docker/commands/gui.py
+++ b/docker/commands/gui.py
@@ -217,7 +217,7 @@ class MainView(MultiView[ViewMode]):
         self._deploy_view.on_select += self.do_deploy
         self.add(ViewMode.DEPLOY, self._deploy_view)
 
-        self._watch_timer = Timer(5, self.refresh_statuses)
+        self._watch_timer = Timer(5, self.refresh_deployment_statuses)
 
         self._cached_statuses = dict()
 
@@ -326,12 +326,13 @@ class MainView(MultiView[ViewMode]):
         return True
 
     async def deployment_selection_changed(self, table: Table):
-        await self._update_statuses(table, False)
+        await self._update_deployment_statuses(False)
 
-    async def refresh_statuses(self):
-        await self._update_statuses(None, True)
+    async def refresh_deployment_statuses(self):
+        await self._update_deployment_statuses(True)
+        self.screen.output()
 
-    async def _update_statuses(self, table, force: False):
+    async def _update_deployment_statuses(self, force: False):
         selected = self._deployments_view.deployments_table.selected_data
         if selected is None:
             self._deployments_view.statuses_table.data = []

--- a/docker/saint/tests/test_timer.py
+++ b/docker/saint/tests/test_timer.py
@@ -34,7 +34,9 @@ class SignalTest(unittest.IsolatedAsyncioTestCase):
         interval = 0.01
         timer = Timer(interval, f)
         timer.start()
-        await asyncio.sleep(interval * n_calls)
+        # subtract 0.5 to not have a 50/50 chance of the last call happening or not,
+        # but instead stop the timer in the midst of the sleep interval after the last expected call.
+        await asyncio.sleep(interval * (n_calls - 0.5))
         timer.stop()
         await asyncio.sleep(interval * n_calls)  # make sure it's really stopped
         self.assertEqual(f.call_count, n_calls)


### PR DESCRIPTION
Internally, the "watch mode" worked fine, but because the watch mode is not user-driven, the internal screen buffer was never dumped to the console, which made the watch mode effectively doing nothing. This fix explicitly dumps the screen buffer to the console after each timer-driven deployment statuses update.