### PR TITLE
fix(ghd): handle nullable commit fields

### DIFF
--- a/docker/github/schema.py
+++ b/docker/github/schema.py
@@ -41,14 +41,15 @@ class DeploymentStatus:
 @dataclass
 class GitActor:
     name: str
+    email: str
     date: str
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class CommitDetails:
-    committer: GitActor
-    author: GitActor
+    committer: Optional[GitActor]
+    author: Optional[GitActor]
     message: str
 
 
@@ -65,8 +66,8 @@ class CommitParent:
 class Commit:
     sha: str
     commit: CommitDetails
-    committer: Actor
-    author: Actor
+    committer: Optional[Actor]
+    author: Optional[Actor]
     parents: list[CommitParent]
 
 


### PR DESCRIPTION
The fields `author` and `committer` can be null for certain commits. For instance, this can happen when a user was removed from a repository's organization.

Without this PR this will result in a crash of ghd. This PR will either display in order of preference:
- the github user data
- the git commit data
- fallback to `<unknown>` if no author or committer could be determined with the methods above