### PR TITLE
feat: verify GitHub check suites statuses before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,10 @@ Commands:
 #### Link ghd to PATH
 
 To use `ghd` from every location on your system, link the shell wrapper to your PATH.
-```
-echo 'export PATH="~/path/to/ghd:$PATH"' >> ~/.profile
-```
-or
-```
-ln -s ~/path/to/ghd/ghd $HOME/bin/
-```
+
+1. Create a new directory to hold symlink: `mkdir $HOME/.bin`
+2. Create symlink to `ghd`: `ln -s ~/path/to/ghd/ghd $HOME/.bin/`
+3. Add `export PATH="$HOME/.bin:$PATH"` to `.profile`/`.zshrc`/`.bashrc`/`.bash_profile`/etc.
 
 #### Deployment
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
 
 runs:
   using: docker
-  image: docker://moneymeets/ghd:v2
+  image: docker://moneymeets/ghd:v3
   env:
     GITHUB_USER: ${{ inputs.user }}
     GITHUB_TOKEN: ${{ inputs.access_token }}

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -191,7 +191,6 @@ class GitHub:
         production: bool,
         task: str,
         description: str,
-        required_contexts: Optional[list[str]],
         payload: Optional[Any] = None,
     ) -> int:
         deployment_creation_result = await self.post(
@@ -204,7 +203,7 @@ class GitHub:
                 "production_environment": production,
                 "task": task,
                 "description": description,
-                "required_contexts": required_contexts,
+                "required_contexts": [],
                 "payload": json.dumps(payload) if payload else "",
             },
         )
@@ -227,3 +226,13 @@ class GitHub:
                     url = response.links.getone("next").getone("url")
                 except KeyError:
                     return result
+
+    async def get_check_suites(self, ref: str) -> list:
+        # https://docs.github.com/en/rest/reference/checks#list-check-suites-for-a-git-reference
+        response = await self.get(f"/repos/{self.repo_path}/commits/{ref}/check-suites")
+        GithubError.raise_from_message(response)
+
+        if "check_suites" not in response:
+            raise KeyError
+
+        return response["check_suites"]

--- a/util.py
+++ b/util.py
@@ -1,5 +1,4 @@
 from functools import wraps
-from typing import Optional
 
 import click
 
@@ -41,19 +40,6 @@ def bool_to_str(b):
         return color_success("yes")
     else:
         return color_error("no")
-
-
-def parse_require_context(require_context: list[str]) -> tuple[Optional[list[str]], str]:
-    if "-" in require_context:
-        if len(require_context) != 1:
-            raise RuntimeError("When not requiring any context by using '-', no other contexts must be required")
-        return [], color_error("none")
-    elif "+" in require_context:
-        if len(require_context) != 1:
-            raise RuntimeError("When requiring all contexts by using '+', no other contexts must be required")
-        return None, color_success("all")
-    else:
-        return require_context, color_unknown(", ".join(require_context))
 
 
 class DependentOptionDefault(click.Option):


### PR DESCRIPTION
1. Use [GitHub check suites](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api) to verify commit status before deployment. A check suite is a collection of the check runs created by a single GitHub App for a specific commit. Check suites summarize the status and conclusion of the check runs that a suite includes. Previously we used `required_context` argument when [creating a new GitHub deployment](https://docs.github.com/en/rest/reference/deployments#create-a-deployment) to force deploy or to verify all check runs that must be in success state. But it doesn't work for when CI pipeline have some check runs in a skipped state.
2. `--require-context` flag was replaced with `--force`. Don't forget to replace old flag in your code.

I've already done deployment tests on my private repository. But we need to test new ghd version against our real repositories and specific cases:

- [x] Test deployment to dev
- [x] Test deployment to dev when summary commit CI status is failed
- [x] Test deployment to dev when summary commit CI status is success, but some of the runs are in skipped state
- [x] Test promote from test to live
- [x] Test promote from dev to test when deploying to dev is not finished yet
- [x] Test force promote from test to live when deploying to test is not finished yet
- [x] Test `--force` flag for deployment from command line